### PR TITLE
Auto-update when a new core/contrib release occurs

### DIFF
--- a/.github/workflows/auto-update.yaml
+++ b/.github/workflows/auto-update.yaml
@@ -1,0 +1,23 @@
+name: Auto-update
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+
+jobs:
+  build:
+    name: Auto-update on new core/contrib versions
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+      - name: Auto-update
+        run: ./scripts/update-to-latest-otelcol.sh -c

--- a/scripts/update-to-latest-otelcol.sh
+++ b/scripts/update-to-latest-otelcol.sh
@@ -8,6 +8,12 @@ if [ $? != 0 ]; then
     exit 1
 fi
 
+num_open_autoupdate_prs=$(gh pr list -l auto-update | wc -l)
+if (( num_open_autoupdate_prs > 0 )); then
+    echo "There are auto-update PRs waiting to be closed or merged. Skipping."
+    exit 0
+fi
+
 while getopts d:c: flag
 do
     case "${flag}" in

--- a/scripts/update-to-latest-otelcol.sh
+++ b/scripts/update-to-latest-otelcol.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+REPO_DIR="$( cd "$(dirname $( dirname "${BASH_SOURCE[0]}" ))" &> /dev/null && pwd )"
+
+command -v gh 2>/dev/null
+if [ $? != 0 ]; then
+    echo "The command 'gh' is expected to exist and be configured in order to update to the latest otelcol."
+    exit 1
+fi
+
+while getopts d:c: flag
+do
+    case "${flag}" in
+        d) directory=${OPTARG};;
+        c) create_pr=${OPTARG};;
+    esac
+done
+
+if [[ -z $directory ]]; then
+    directory=$(mktemp -d)
+    echo "Directory containing the release JSON files not provided. Created '${directory}' to host the latest from GitHub."
+    gh api -H "Accept: application/vnd.github+json" /repos/open-telemetry/opentelemetry-collector/releases/latest > "${directory}/latest-core.json"
+    gh api -H "Accept: application/vnd.github+json" /repos/open-telemetry/opentelemetry-collector-contrib/releases/latest > "${directory}/latest-contrib.json"
+fi
+
+# get the latest tag, without the "v" prefix
+latest_core_version=$(jq -r .tag_name "${directory}/latest-core.json" | sed 's/^v//')
+latest_contrib_version=$(jq -r .tag_name "${directory}/latest-contrib.json" | sed 's/^v//')
+
+# in theory, we could have independent pull requests for each version bump, 
+# but it's better to have the versions in sync at all times to prevent build failures
+if [ $latest_core_version != $latest_contrib_version ]; then
+    echo "The contrib and core versions aren't matching. This might be OK, but perhaps there's a release in process?"
+    core_date=$(date -d $(jq -r .published_at latest-core.json) +%s)
+    contrib_date=$(date -d $(jq -r .published_at latest-contrib.json) +%s)
+
+    # the idea now is the following: if we just detected a new release of the core but not contrib yet,
+    # then the release process might still be happening. Let's give it, say, 6 hours to complete.
+    # If contrib's release is newer than core's, assume they are in sync already
+    # If contrib is older than core, and core has been released more than 6 hours ago, go ahead anyway
+    # Otherwise, skip the version bump
+    if (( $contrib_date < $core_date )); then
+        hours_between_releases=$(((contrib_date-core_date)/(60*60)))
+        if (( hours_between_releases < 6 )); then
+            echo "There seems to be a core release in process, skipping."
+            exit 0
+        fi
+    fi
+fi
+
+# at this point, we are ready to start replacing the versions on the manifests
+manifests=$(find ${REPO_DIR} -name manifest.yaml)
+for manifest in $manifests; do
+    echo "Updating $manifest"
+    # the first token to replace is the otelcol_version
+    sed -i "s~otelcol_version.*~otelcol_version: ${latest_core_version}~" $manifest
+
+    # now, the collector gomod:
+    sed -i "s~gomod: go\.opentelemetry\.io/collector.*~gomod: go.opentelemetry.io/collector v${latest_core_version}~" $manifest
+
+    # and the contrib versions:
+    # this captures a group with the "- gomod: component-path" content, and use it plus the version to compose the line 
+    sed -i "s~\(.*github.com/open-telemetry/opentelemetry-collector-contrib/.*\s\).*~\1v${latest_contrib_version}~" $manifest
+done
+
+git diff --quiet $manifests
+if [[ $? == 0 ]]; then
+    echo "We are already at the latest versions."
+    exit 0
+fi
+
+# add only the files we might have changed
+git add $manifests
+
+# are there other changes?
+git diff --quiet
+if [[ $? != 0 ]]; then
+    echo "More changes detected than expected! Aborting."
+    exit 1
+fi
+
+git commit -sm "Bump OpenTelemetry core and/or contrib versions"
+
+if [[ "$create_pr" = true ]]; then
+    echo "Creating the pull request on your behalf."
+    gh pr create --title  "Bump OpenTelemetry core and/or contrib" --body "Use OpenTelemetry core v${latest_core_version} and contrib v${latest_contrib_version} in the manifests."
+else
+    echo "I could have created the pull request on your behalf if you had used the '-c' option."
+fi


### PR DESCRIPTION
The script was tested manually on my local machine, up to the 'gh pr create' command, which can't be tested without this change here being incorporated first.

The workflow wasn't tested at all, as there's only way to test it: running it.

Fixes #6

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>