### PR TITLE
Update download URL for ocb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ ifeq (, $(shell command -v ocb 2>/dev/null))
 	[ "$${machine}" != x86_64 ] || machine=amd64 ;\
 	echo "Installing ocb ($${os}/$${machine}) at $(OTELCOL_BUILDER_DIR)";\
 	mkdir -p $(OTELCOL_BUILDER_DIR) ;\
-	curl -sLo $(OTELCOL_BUILDER) "https://github.com/open-telemetry/opentelemetry-collector/releases/download/v$(OTELCOL_BUILDER_VERSION)/ocb_$(OTELCOL_BUILDER_VERSION)_$${os}_$${machine}" ;\
+	curl -sLo $(OTELCOL_BUILDER) "https://github.com/open-telemetry/opentelemetry-collector/releases/download/cmd%2Fbuilder%2Fv$(OTELCOL_BUILDER_VERSION)/ocb_$(OTELCOL_BUILDER_VERSION)_$${os}_$${machine}" ;\
 	chmod +x $(OTELCOL_BUILDER) ;\
 	}
 else


### PR DESCRIPTION
ocb has its own tag now on the core repository, causing the download URL to change. This PR makes the Makefile use the new location.

When `ocb` is not on the path, the following happens:

```
> make generate-sources
Installing ocb (linux/amd64) at /home/jpkroehling/bin
Skipping the compilation, we'll only generate the sources.
Distributions to build: sidecar,tracing,otel-grafana
Building: sidecar
Using Builder: /home/jpkroehling/bin/ocb
Using Go: /usr/bin/go
❌ ERROR: failed to build the distribution 'sidecar'.
🪵 Build logs for 'sidecar'
----------------------
/home/jpkroehling/bin/ocb: line 1: Not: command not found
----------------------
make: *** [Makefile:24: generate-sources] Error 1
```

After this change:

```
> make generate-sources
Installing ocb (linux/amd64) at /home/jpkroehling/bin
Skipping the compilation, we'll only generate the sources.
Distributions to build: sidecar,tracing,otel-grafana
Building: sidecar
Using Builder: /home/jpkroehling/bin/ocb
Using Go: /usr/bin/go
✅ SUCCESS: distribution 'sidecar' built.
Building: tracing
Using Builder: /home/jpkroehling/bin/ocb
Using Go: /usr/bin/go
✅ SUCCESS: distribution 'tracing' built.
Building: otel-grafana
Using Builder: /home/jpkroehling/bin/ocb
Using Go: /usr/bin/go
✅ SUCCESS: distribution 'otel-grafana' built.
```

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
