### PR TITLE
Add gcom api and routing processors to otel-grafana distribution.

### DIFF
--- a/distributions/otel-grafana/manifest.yaml
+++ b/distributions/otel-grafana/manifest.yaml
@@ -11,11 +11,11 @@ extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.70.0
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.70.0
+processors:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.70.0
+  - gomod: github.com/grafana/opentelemetry-collector-components/processor/gcomapiprocessor v0.0.0
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.70.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter v0.70.0
-
-excludes:
-  - cloud.google.com/go v0.65.0
-  - cloud.google.com/go v0.34.0
-  - cloud.google.com/go v0.26.0
+replaces:
+  - github.com/grafana/opentelemetry-collector-components/processor/gcomapiprocessor => ../../../components/processor/gcomapiprocessor/


### PR DESCRIPTION
Add Grafana com API and routing processors to otel-grafana distribution.


Example config for [OTLP gateway](https://docs.google.com/document/d/1HsJr5eVH4WOdSSGIeaYRRUGAqx4Bzx-CSna1mspW4a4/edit#heading=h.89ldx0hih690).

```yaml
receivers:
  otlp:
    protocols:
      grpc:
        include_metadata: true
      http:
        include_metadata: true

exporters:
  otlp/2:
    endpoint: <prom>
  otlp/1:
    endpoint: <tempo>

processors:
  gcomapi:
    client:
      endpoint: "mock://fake:3000"
      key: "fake"
  routing:
    attribute_source: context
    from_attribute: "X-Scope-InstanceURL"
    table:
    - exporters: [otlp/1]
      value: "https://tempo-dev-01-dev-us-central-0.grafana.net"
    - exporters: [ otlp/2 ]
       value: "https://prometheus-dev-01-dev-us-central-0.grafana.net"

service:
  pipelines:
    traces:
      receivers: [otlp]
      processors: [gcomapi, routing]
      exporters: [otlp/1]
    metrics:
      receivers: [otlp]
      processors: [gcomapi, routing]
      exporters: [otlp/2]
```


