### PR TITLE
Use goreleaser-pro

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
+          distribution: goreleaser-pro
           version: latest
           args: release --clean --timeout 2h --nightly
         env:


### PR DESCRIPTION
Required for nightly (CD) builds

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
