### PR TITLE
Revert "gcomapiprocessor: CanonicalHeaderKey for X-Scope-OrgID (#60)"

### DIFF
--- a/components/processor/gcomapiprocessor/processor.go
+++ b/components/processor/gcomapiprocessor/processor.go
@@ -3,7 +3,6 @@ package gcomapiprocessor
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"strconv"
 
 	collectorclient "go.opentelemetry.io/collector/client"
@@ -82,8 +81,7 @@ func (p *grafanaAPIProcessor) enrichContextWithSignalInstanceURL(
 
 	// Extract X-Scope-OrgID
 	info := collectorclient.FromContext(ctx)
-	key := http.CanonicalHeaderKey(orgID)
-	v := info.Metadata.Get(key)
+	v := info.Metadata.Get(orgID)
 
 	if v == nil || len(v) == 0 {
 		return nil, fmt.Errorf("missing %q header", orgID)

--- a/components/processor/gcomapiprocessor/processor_test.go
+++ b/components/processor/gcomapiprocessor/processor_test.go
@@ -3,7 +3,6 @@ package gcomapiprocessor
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"strconv"
 	"testing"
 
@@ -37,18 +36,6 @@ func TestProcessor_EnrichContextWithSignalInstanceURL(t *testing.T) {
 				return collectorclient.NewContext(context.Background(), collectorclient.Info{
 					Metadata: collectorclient.NewMetadata(
 						map[string][]string{orgID: {strconv.Itoa(gcom.GrafanaInstanceOne.ID)}},
-					),
-				})
-			},
-			want: gcom.GrafanaInstanceOne.TracesInstanceURL,
-		},
-		{
-			name: "canonical id header",
-			context: func() context.Context {
-				canonicalOrgID := http.CanonicalHeaderKey(orgID)
-				return collectorclient.NewContext(context.Background(), collectorclient.Info{
-					Metadata: collectorclient.NewMetadata(
-						map[string][]string{canonicalOrgID: {strconv.Itoa(gcom.GrafanaInstanceOne.ID)}},
 					),
 				})
 			},


### PR DESCRIPTION
This reverts commit 6b91740ce3d41dd6498e5be60a5a118409618398.

Closes #61
